### PR TITLE
Fix problem when after reinstall of the app, keychain had items from …

### DIFF
--- a/Wallet/Wallet/Core/App.swift
+++ b/Wallet/Wallet/Core/App.swift
@@ -22,8 +22,8 @@ class App {
     let exchangeRateManager: IExchangeRateManager
 
     init() {
-        secureStorage = KeychainStorage()
         localStorage = UserDefaultsStorage()
+        secureStorage = KeychainStorage(localStorage: localStorage)
         wordsManager = WordsManager(secureStorage: secureStorage, localStorage: localStorage)
 
         pinManager = PinManager(secureStorage: secureStorage)

--- a/Wallet/Wallet/Core/Managers/PinManager.swift
+++ b/Wallet/Wallet/Core/Managers/PinManager.swift
@@ -9,7 +9,7 @@ class PinManager {
 
 extension PinManager: IPinManager {
 
-    var isPinned: Bool {
+    var isPinSet: Bool {
         return secureStorage.pin != nil
     }
 

--- a/Wallet/Wallet/Core/Protocols.swift
+++ b/Wallet/Wallet/Core/Protocols.swift
@@ -102,7 +102,7 @@ protocol IBlurManager {
 }
 
 protocol IPinManager {
-    var isPinned: Bool { get }
+    var isPinSet: Bool { get }
     func store(pin: String?) throws
     func validate(pin: String) -> Bool
 }

--- a/Wallet/Wallet/Core/Protocols.swift
+++ b/Wallet/Wallet/Core/Protocols.swift
@@ -11,6 +11,8 @@ protocol ILocalStorage: class {
     var isBiometricOn: Bool { get set }
     var currentLanguage: String? { get set }
     var lastExitDate: Double { get set }
+    var didLaunchOnce: Bool { get }
+    func clear()
 }
 
 protocol ISecureStorage: class {
@@ -18,6 +20,7 @@ protocol ISecureStorage: class {
     func set(words: [String]?) throws
     var pin: String? { get }
     func set(pin: String?) throws
+    func clear()
 }
 
 protocol ILanguageManager {

--- a/Wallet/Wallet/Core/Storage/KeychainStorage.swift
+++ b/Wallet/Wallet/Core/Storage/KeychainStorage.swift
@@ -2,10 +2,17 @@ import Foundation
 import KeychainAccess
 
 class KeychainStorage {
-    let keychain = Keychain(service: "io.horizontalsystems.bank.dev")
+    let keychain: Keychain
 
     private let pinKey = "pin_keychain_key"
     private let wordsKey = "words_keychain_key"
+
+    init(localStorage: ILocalStorage) {
+        keychain = Keychain(service: "io.horizontalsystems.bank.dev")
+        if !localStorage.didLaunchOnce {
+            clear()
+        }
+    }
 
     func getBool(forKey key: String) -> Bool? {
         guard let string = keychain[key] else {
@@ -69,6 +76,11 @@ extension KeychainStorage: ISecureStorage {
 
     func set(pin: String?) throws {
         try set(value: pin, forKey: pinKey)
+    }
+
+    func clear() {
+        try? set(words: nil)
+        try? set(pin: nil)
     }
 
 }

--- a/Wallet/Wallet/Core/Storage/UserDefaultsStorage.swift
+++ b/Wallet/Wallet/Core/Storage/UserDefaultsStorage.swift
@@ -8,6 +8,7 @@ class UserDefaultsStorage: ILocalStorage {
     private let iUnderstandKey = "i_understand_key"
     private let biometricOnKey = "biometric_on_key"
     private let lastExitDateKey = "last_exit_date_key"
+    private let didLaunchOnceKey = "did_launch_once_key"
 
     var isBackedUp: Bool {
         get { return bool(for: keyIsBackedUp) ?? false }
@@ -24,6 +25,14 @@ class UserDefaultsStorage: ILocalStorage {
         set { set(newValue, for: lastExitDateKey) }
     }
 
+    var didLaunchOnce: Bool {
+        if bool(for: didLaunchOnceKey) ?? false {
+            return true
+        }
+        set(true, for: didLaunchOnceKey)
+        return false
+    }
+
     var lightMode: Bool {
         get { return bool(for: keyLightMode) ?? false }
         set { set(newValue, for: keyLightMode) }
@@ -37,6 +46,13 @@ class UserDefaultsStorage: ILocalStorage {
     var isBiometricOn: Bool {
         get { return bool(for: biometricOnKey) ?? false }
         set { set(newValue, for: biometricOnKey) }
+    }
+
+    func clear() {
+        isBackedUp = false
+        lightMode = false
+        iUnderstand = false
+        isBiometricOn = false
     }
 
     private func getString(_ name: String) -> String? {

--- a/Wallet/Wallet/Modules/Backup/BackupInteractor.swift
+++ b/Wallet/Wallet/Modules/Backup/BackupInteractor.swift
@@ -43,7 +43,7 @@ extension BackupInteractor: IBackupInteractor {
     }
 
     func lockIfRequired() {
-        if pinManager.isPinned {
+        if pinManager.isPinSet {
             delegate?.showUnlock()
         } else {
             fetchWords()

--- a/Wallet/Wallet/Modules/Launch/LaunchInteractor.swift
+++ b/Wallet/Wallet/Modules/Launch/LaunchInteractor.swift
@@ -19,9 +19,6 @@ extension LaunchInteractor: ILaunchInteractor {
 
     func showLaunchModule() {
         if !wordsManager.isLoggedIn {
-            // todo: another implementation is required, because it does not work when we logout / login without killing the app
-            try? pinManager.store(pin: nil)
-
             delegate?.showGuestModule()
         } else if pinManager.isPinned {
             adapterManager.start()

--- a/Wallet/Wallet/Modules/Launch/LaunchInteractor.swift
+++ b/Wallet/Wallet/Modules/Launch/LaunchInteractor.swift
@@ -20,7 +20,7 @@ extension LaunchInteractor: ILaunchInteractor {
     func showLaunchModule() {
         if !wordsManager.isLoggedIn {
             delegate?.showGuestModule()
-        } else if pinManager.isPinned {
+        } else if pinManager.isPinSet {
             adapterManager.start()
             delegate?.showMainModule()
             lockManager.lock()

--- a/Wallet/Wallet/Modules/Settings/Main/MainSettingsViewController.swift
+++ b/Wallet/Wallet/Modules/Settings/Main/MainSettingsViewController.swift
@@ -151,8 +151,7 @@ class MainSettingsViewController: UIViewController, SectionsDataSource {
     }
 
     func logout() {
-        App.shared.localStorage.isBiometricOn = false
-        App.shared.localStorage.isBackedUp = false
+        App.shared.localStorage.clear()
         App.shared.wordsManager.removeWords()
         App.shared.adapterManager.clear()
         try? App.shared.pinManager.store(pin: nil)

--- a/Wallet/Wallet/Modules/Settings/Security/SecuritySettingsViewController.swift
+++ b/Wallet/Wallet/Modules/Settings/Security/SecuritySettingsViewController.swift
@@ -72,8 +72,8 @@ class SecuritySettingsViewController: UIViewController, SectionsDataSource {
         default: ()
         }
 
-        let setOrChangePinTitle = App.shared.pinManager.isPinned ? "settings_security.change_pin".localized : "settings_security.set_pin".localized
-        pinTouchFaceRows.append(Row<SettingsCell>(id: "set_pin", hash: "pinned_\(App.shared.pinManager.isPinned)", height: SettingsTheme.securityCellHeight, bind: { cell, _ in
+        let setOrChangePinTitle = App.shared.pinManager.isPinSet ? "settings_security.change_pin".localized : "settings_security.set_pin".localized
+        pinTouchFaceRows.append(Row<SettingsCell>(id: "set_pin", hash: "pinned_\(App.shared.pinManager.isPinSet)", height: SettingsTheme.securityCellHeight, bind: { cell, _ in
             cell.bind(titleIcon: nil, title: setOrChangePinTitle, showDisclosure: true, last: true)
         }, action: { [weak self] _ in
             self?.delegate.didTapEditPin()


### PR DESCRIPTION
…previous user.

- add `launchedOnce` param to local storage.

Add `clear` method to secure and local storage protocols.